### PR TITLE
chore: release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.0] - 2021-04-08
+
+* Support null safety
+
+* Clean up unused code and debug prints in iOS native part
+
+* Update and and clean up example code
+
 ## [1.0.0] - 2020-07-16
 
 * Initial release

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.chihimng.is_lock_screen'
-version '1.0.0'
+version '2.0.0'
 
 buildscript {
     ext.kotlin_version = '1.3.50'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:

--- a/ios/is_lock_screen.podspec
+++ b/ios/is_lock_screen.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'is_lock_screen'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Detects if device is in lock screen.'
   s.description      = <<-DESC
 Detects if device is in lock screen. Useful for determining whether app entered background due to locking screen or leaving app.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: is_lock_screen
 description: Detects if device is in lock screen. Useful for determining whether app entered background due to locking screen or leaving app.
-version: 1.0.0
+version: 2.0.0
 repository: https://github.com/chihimng/flutter_is_lock_screen
 
 environment:

--- a/test/is_lock_screen_test.dart
+++ b/test/is_lock_screen_test.dart
@@ -1,6 +1,2 @@
-import 'package:flutter_test/flutter_test.dart';
-
-import 'package:is_lock_screen/is_lock_screen.dart';
-
 void main() {
 }


### PR DESCRIPTION
Release new major version to support null safety.

Ref: https://dart.dev/null-safety/migration-guide

- `dart pub outdated --mode=null-safety`: All your dependencies declare support for null-safety.
- Code migration: Done via #2
- `flutter analyze`: Passed
- `flutter test`: We don't have test cases yet 🙈 
- SDK constraint: Set to `>=2.12.0 <3.0.0`
- Package version: Bumped major version number
- `dart pub publish --dry-run`: Passed
